### PR TITLE
增加mongodb6.x启动命令

### DIFF
--- a/apps/notify/sms.go
+++ b/apps/notify/sms.go
@@ -31,7 +31,11 @@ func LoadTencentSmsConfigFromEnv() (*TencentSmsConfig, error) {
 // NewTencentSmsConfig todo
 func NewTencentSmsConfig() *TencentSmsConfig {
 	return &TencentSmsConfig{
-		Endpoint: DEFAULT_TENCENT_SMS_ENDPOINT,
+		Endpoint:  DEFAULT_TENCENT_SMS_ENDPOINT,
+		SecretId:  "default_secretId",
+		SecretKey: "default_secretKey",
+		AppId:     "default_id",
+		Sign:      "default_sign",
 	}
 }
 

--- a/docs/mongodb/install.md
+++ b/docs/mongodb/install.md
@@ -36,7 +36,7 @@ systemctl enable mongod
 
 ```
 docker pull mongo
-docker run -itd -p 27017:27017 --name mongo mongo
+docker run -itd -p 27017:27017 --name mongo mongo --auth
 ```
 
 # 创建管理用户
@@ -44,6 +44,10 @@ docker run -itd -p 27017:27017 --name mongo mongo
 进入Mongo Shell
 ```
 docker exec -it mongo mongo
+```
+进入Mongo Shell 6.x
+```
+docker exec -it mongo mongosh
 ```
 
 创建管理员账号


### PR DESCRIPTION
dockerhub上默认的版本已是6.x，命令跟之前有出入。